### PR TITLE
generate admin

### DIFF
--- a/examples/admin-gatsby/packages/admin/scripts/generatePages.ts
+++ b/examples/admin-gatsby/packages/admin/scripts/generatePages.ts
@@ -1,9 +1,13 @@
 import { generateAdmin, Schema } from '@prisma-tools/admin';
 import defaultSchema from '../../server/src/graphql/schema/schema.json';
+import path from 'path';
 
-generateAdmin('./packages/server/prisma/schema.prisma', defaultSchema as Schema, {
+generateAdmin(path.resolve(__dirname, '../../server/prisma/schema.prisma'), defaultSchema as Schema, {
   excludeFieldsByModel: {
     User: ['password'],
   },
   excludeQueriesAndMutations: ['updateMany', 'deleteMany'],
+  schemaOutput: path.resolve(__dirname, '../../server/src/graphql/schema/schema.json'),
+  graphqlOutput: path.resolve(__dirname, '../../admin/src/graphql'),
+  pagesOutput: path.resolve(__dirname, '../../admin/src/pages/models'),
 });

--- a/packages/admin/src/mergeSchema.ts
+++ b/packages/admin/src/mergeSchema.ts
@@ -9,7 +9,9 @@ export function mergeSchema(object: SchemaObject, schema: Schema): Schema {
   object.models.forEach((item) => {
     const schemaItem = schema.models.find((model) => model.id === item.name);
     if (!schemaItem) {
-      newSchema.models.push(handleNewModel(item));
+      if (checkIdFieldExist(item)) {
+        newSchema.models.push(handleNewModel(item));
+      }
     } else {
       const newItem: SchemaModel = {
         ...schemaItem,
@@ -22,7 +24,7 @@ export function mergeSchema(object: SchemaObject, schema: Schema): Schema {
       };
       item.fields.forEach((field) => {
         const schemaField = schemaItem.fields.find(
-          (item) => item.name === field.name
+          (item) => item.name === field.name,
         );
         if (!schemaField) {
           newItem.fields.push(handleNewField(field, schemaItem.name));
@@ -38,6 +40,10 @@ export function mergeSchema(object: SchemaObject, schema: Schema): Schema {
     }
   });
   return newSchema;
+}
+
+function checkIdFieldExist(model: Model) {
+  return !!model.fields.find((field) => field.isId);
 }
 
 function handleNewModel(model: Model) {
@@ -80,7 +86,7 @@ function getTitle(id: string) {
 
 function getOriginalField(
   field: Field,
-  modelName: string
+  modelName: string,
 ): Omit<Field, 'relation'> & { id: string } {
   delete field.relation;
   return {


### PR DESCRIPTION
1. absolute path might be required in the example to generate admin from schema.
2. i added checkIdExists function as a temporary solution to block many to many relationships handling from prisma, as those relationships sometimes lack id field in the model file declaration. 

```
model Post {
  id         Int                 @id @default(autoincrement())
  title      String
  categories CategoriesOnPosts[]
}
model Category {
  id    Int                 @id @default(autoincrement())
  name  String
  posts CategoriesOnPosts[]
}
model CategoriesOnPosts {
  post        Post     @relation(fields: [postId], references: [id])
  postId      Int       // relation scalar field (used in the `@relation` attribute above)
  category    Category @relation(fields: [categoryId], references: [id])
  categoryId  Int      // relation scalar field (used in the `@relation` attribute above)
  createdAt   DateTime @default(now())
  @@id([postId, categoryId])
}
```