### PR TITLE
admin many to many 

### DIFF
--- a/examples/admin-gatsby/packages/admin/src/components/Table/useFilterAndSort.ts
+++ b/examples/admin-gatsby/packages/admin/src/components/Table/useFilterAndSort.ts
@@ -14,7 +14,19 @@ const filterMemo = (modelName: string, filter?: any) => {
         if (model && filter[key]) {
           const field = model.fields.find((item) => item.type === key);
           const fieldModel = models.find((item) => item.id === field?.type);
-          if (fieldModel) {
+          if (field.many) {
+            const relationId = model.name.toLowerCase() + 'Id'
+            initialValue.push({
+              id: field ? field.name : key,
+              value: {
+                every: {
+                  [relationId]: {
+                    equals: parseInt(filter[key]),
+                  },
+                },
+              },
+            })
+          } else {
             initialValue.push({
               id: field ? field.name : key,
               value: {
@@ -22,7 +34,7 @@ const filterMemo = (modelName: string, filter?: any) => {
                   equals: parseInt(filter[key]),
                 },
               },
-            });
+            })
           }
           if (key === 'id') {
             initialValue.push({

--- a/examples/admin-gatsby/packages/admin/src/graphql/Schema.graphql
+++ b/examples/admin-gatsby/packages/admin/src/graphql/Schema.graphql
@@ -28,6 +28,7 @@ fragment Field on Field {
   sort
   filter
   relationField
+  many
 }
 
 fragment Enum on Enum {

--- a/examples/admin-gatsby/packages/server/src/graphql/schema/db.ts
+++ b/examples/admin-gatsby/packages/server/src/graphql/schema/db.ts
@@ -21,7 +21,23 @@ export const SchemaQueries = extendType({
     t.field('getSchema', {
       type: 'Schema',
       resolve: async () => {
-        return db.value()
+        let dbValue = db.value()
+        for (let i = 0; i < dbValue.models.length; i++) {
+          const model = dbValue.models[i].name
+          for (let j = 0; j < dbValue.models[i].fields.length; j++) {
+            const field = dbValue.models[i].fields[j]
+            if (field.type.includes('On')) {
+              const fieldModels = field.type.split('On')
+              field.many = true
+              if (fieldModels[0] === model) {
+                field.type = fieldModels[1]
+              } else if (fieldModels[1] === model) {
+                field.type = fieldModels[0]
+              }
+            }
+          }
+        }
+        return dbValue
       },
     })
   },


### PR DESCRIPTION
Currently, when a model has a many to many relationship using prisma's recommended way of syntax (ex: "ProductOnCategory" with @id(productId, categoryId)), the admin cant fetch the relationship correctly. My previous pull request suggested to omit many to many relationship on admin page auto generation. To further support it to make fetching many to many correctly. i am proposing this possible solution to tackle down the issue. 

Current implementation requires users to follow prisma naming convention on models like (ex: "ProductOnCategory" with @id(productId, categoryId))

Im open to discuss how to make this better