### PR TITLE
Fix Jest path resolution and ensure build before tests

### DIFF
--- a/tsconfig.build.bundle.json
+++ b/tsconfig.build.bundle.json
@@ -2,6 +2,7 @@
   // useful for bundling because esbuild can then tree-shake via the paths
   "extends": "./tsconfig.build.regular.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "@paljs/types": ["./packages/types/src"],
       "@paljs/schema": ["./packages/schema/src"],


### PR DESCRIPTION
## Summary
- fix TS path resolution by setting `baseUrl` in `tsconfig.build.bundle.json`
- `pnpm test` requires packages to be built first; after building, tests pass

## Testing
- `pnpm test`